### PR TITLE
SciOps GPU worker EFS access update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,11 @@ ENV PATH /home/muser/.MATLAB/bin:${PATH}
 RUN groupadd ubuntu --gid 1000
 RUN usermod -aG ubuntu muser
 
+RUN groupadd anaconda --gid 999
+RUN usermod -aG anaconda muser
+
 # mkdir for everything
-USER muser
+USER muser:anaconda
 RUN mkdir /home/muser/neuropixel
 WORKDIR /home/muser/neuropixel
 

--- a/Dockerfile.jhub
+++ b/Dockerfile.jhub
@@ -1,0 +1,9 @@
+# docker buildx build -t vathes/sciops-demo-workflow-1:v0.0.1 . --load && docker push vathes/sciops-demo-workflow-1:v0.0.1
+FROM datajoint/djlabhub:1.4.2-py3.8-debian
+
+# WORKDIR ./workflow
+# RUN ls -la /tmp && exit 1
+
+RUN \
+    umask u+rwx,g+rwx,o-rwx && \ 
+    pip install git+https://github.com/vathes/sciops-demo-workflow-1

--- a/apt_requirements.txt
+++ b/apt_requirements.txt
@@ -1,4 +1,3 @@
 locales-all
 vim
 wget
-curl

--- a/mount-fsap-sciops.sh
+++ b/mount-fsap-sciops.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Need to build and install: https://docs.aws.amazon.com/efs/latest/ug/overview-amazon-efs-utils.html
-# Remember to run this script with sudo
-mount -t efs -o tls,accesspoint=fsap-0bc63e40c6bffd915 fs-5271d529: /mnt/sciops

--- a/mount-fsap-sciops.sh
+++ b/mount-fsap-sciops.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Need to build and install: https://docs.aws.amazon.com/efs/latest/ug/overview-amazon-efs-utils.html
+# Remember to run this script with sudo
+mount -t efs -o tls,accesspoint=fsap-0bc63e40c6bffd915 fs-5271d529: /mnt/sciops


### PR DESCRIPTION
Changelog:
- Previously, host machine directly mounts to entire efs at /mnt/efs-sciops. Now it's mounting to a efs access point(fsap) at /mnt/sciops. **Which means this requires changing on the .env file when docker-compose up**
- Added efs access point mounting script as reference
- Added a new group for workers to access efs access point(secondary gid).